### PR TITLE
Update recommended resources and clean heading styles

### DIFF
--- a/_includes/recommended-resources.html
+++ b/_includes/recommended-resources.html
@@ -2,7 +2,7 @@
 <section class="section tags">
     <div class="container">
       <div class="row">
-        <div class="col col-12">
+        <div class="col">
           <div class="tags__head text-center">
             <h1 class="tags__title">Activities</h1>
           </div>
@@ -12,7 +12,7 @@
           <div class="tags__content row">
             {% assign include_tags = "Courses, RDMbites" | split: ", " %}
             {% for item in (0..site.tags.size) %} {% unless forloop.last %} {% capture this_word %}{{ tag_words[item] | strip_newlines }}{% endcapture %} {% if include_tags contains this_word %}
-            <div class="col tags__content__item">
+            <div class="tags__content__item">
               <a href="{{ site.baseurl }}/tags/?tag={{ this_word | cgi_escape }}">
                 <span class="tag-name" >{{ this_word }}</span>
                 <span class="tag__counter">{{ site.tags[this_word].size }}</span>

--- a/_includes/recommended-resources.html
+++ b/_includes/recommended-resources.html
@@ -1,0 +1,29 @@
+<!-- begin tags -->
+<section class="section tags">
+    <div class="container">
+      <div class="row">
+        <div class="col col-12">
+          <div class="tags__head text-center">
+            <h1 class="tags__title">Activities</h1>
+          </div>
+          {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+          {% assign tag_words = site_tags | split:',' | sort %}
+  
+          <div class="tags__content row">
+            {% assign include_tags = "Courses, RDMbites" | split: ", " %}
+            {% for item in (0..site.tags.size) %} {% unless forloop.last %} {% capture this_word %}{{ tag_words[item] | strip_newlines }}{% endcapture %} {% if include_tags contains this_word %}
+            <div class="col col-4 col-d-6 col-m-12 tags__content__item">
+              <a href="{{ site.baseurl }}/tags/?tag={{ this_word | cgi_escape }}">
+                <span class="tag-name" >{{ this_word }}</span>
+                <span class="tag__counter">{{ site.tags[this_word].size }}</span>
+              </a>
+            </div>
+            {% endif %}
+            {% endunless %}
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- end tags -->

--- a/_includes/recommended-resources.html
+++ b/_includes/recommended-resources.html
@@ -2,7 +2,7 @@
 <section class="section tags">
     <div class="container">
       <div class="row">
-        <div class="col">
+        <div class="col col-2">
           {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
           {% assign tag_words = site_tags | split:',' | sort %}
           <div class="tags__content row">

--- a/_includes/recommended-resources.html
+++ b/_includes/recommended-resources.html
@@ -12,7 +12,7 @@
           <div class="tags__content row">
             {% assign include_tags = "Courses, RDMbites" | split: ", " %}
             {% for item in (0..site.tags.size) %} {% unless forloop.last %} {% capture this_word %}{{ tag_words[item] | strip_newlines }}{% endcapture %} {% if include_tags contains this_word %}
-            <div class="col col-4 col-d-6 col-m-12 tags__content__item">
+            <div class="col tags__content__item">
               <a href="{{ site.baseurl }}/tags/?tag={{ this_word | cgi_escape }}">
                 <span class="tag-name" >{{ this_word }}</span>
                 <span class="tag__counter">{{ site.tags[this_word].size }}</span>

--- a/_includes/recommended-resources.html
+++ b/_includes/recommended-resources.html
@@ -3,12 +3,8 @@
     <div class="container">
       <div class="row">
         <div class="col">
-          <div class="tags__head text-center">
-            <h1 class="tags__title">Activities</h1>
-          </div>
           {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
           {% assign tag_words = site_tags | split:',' | sort %}
-  
           <div class="tags__content row">
             {% assign include_tags = "Courses, RDMbites" | split: ", " %}
             {% for item in (0..site.tags.size) %} {% unless forloop.last %} {% capture this_word %}{{ tag_words[item] | strip_newlines }}{% endcapture %} {% if include_tags contains this_word %}

--- a/_pages/training_materials.md
+++ b/_pages/training_materials.md
@@ -5,7 +5,13 @@ permalink: /training_materials/
 image: 
 ---
 
-## Training
+## Our Fellowship materials
+Explore the training resources developed by the ELIXIR-UK Fellowship with short courses and bite-size videos. You can reuse, adapt and customise them. 
+
+{% include recommended-resources.html %}
+
+## Other resources 
+See below a list of relevant external resources for longer, more extensive training or other web resources relevant to RDM and FAIR data. 
 
 ### FAIR in (biological) practice – Ed-DaSH
 The course has material on FAIR principles as well as RDM best practices. The great thing about this material is that it can be taught face-to-face as part of The Carpentries or be delivered online/on-demand.
@@ -21,7 +27,6 @@ This online web resource is a fantastic option for those involved with data mana
 
 [Go to training»](https://howtofair.dk/)
 
-## Web resources
 
 ### RDMkit
 Recommended in the Horizon Europe Program Guide as the “resource for Data Management guidelines and good practices for the Life Sciences”, RDMkit is an open community project that has become the go-to for resources based on best practice and guidelines of FAIR data management in the life sciences.
@@ -40,7 +45,6 @@ This is a fantastic resource for anyone working in the life sciences, especially
 
 [Go to resource»](https://www.go-fair.org/fair-principles/)
 
-## Visual resources
 
 ### FAIRsharing Educational
 This collection of infographics and factsheets provides high-level information on a variety of topics relevant to FAIRsharing content across a spectrum of users and in all disciplines. This is an excellent resource with content written by the FAIRsharing team and community champions in the field of FAIR research data management.

--- a/_pages/training_materials.md
+++ b/_pages/training_materials.md
@@ -5,51 +5,48 @@ permalink: /training_materials/
 image: 
 ---
 
-## Our Fellowship materials
-Explore the training resources developed by the ELIXIR-UK Fellowship with short courses and bite-size videos. You can reuse, adapt and customise them. 
+## Dive into ELIXIR-UK Fellowship - Training Resources
+Explore a variety of training materials created by the ELIXIR-UK Fellowship program. These resources include:
+
+- **Short courses:** Get started quickly with concise, focused learning modules. [Go to Courses»](https://fellowship.elixiruknode.org/tags/?tag=Courses)
+- **Bite-size videos:** Learn on the go with short, informative video clips. [Go to RDMbites»](https://fellowship.elixiruknode.org/tags/?tag=RDMbites)
+
+These resources are designed to be adaptable and customisable, allowing you to tailor them to your specific needs and audience.
 
 {% include recommended-resources.html %}
 
-## Other resources 
-See below a list of relevant external resources for longer, more extensive training or other web resources relevant to RDM and FAIR data. 
+## Beyond the Fellowship - External Resources
+While the ELIXIR-UK Fellowship provides a great starting point, numerous external resources can offer more in-depth training or information:
 
-### FAIR in (biological) practice – Ed-DaSH
+### Longer, more extensive training
+ Expand your knowledge through comprehensive training programs on various RDM and FAIR data topics.
+
+- **FAIR in (biological) practice – Ed-DaSH**
 The course has material on FAIR principles as well as RDM best practices. The great thing about this material is that it can be taught face-to-face as part of The Carpentries or be delivered online/on-demand.
 You do not need to have prior knowledge of data management to benefit from this course, but familiarity with spreadsheets (such as Excel) and a bio background will be helpful.
-This is aimed at researchers who are working in the life sciences, and those who wish to have a better understanding of Open Science and FAIR practices.
-
-[Go to training»](https://carpentries-incubator.github.io/fair-bio-practice/)
+This is aimed at researchers who are working in the life sciences, and those who wish to have a better understanding of Open Science and FAIR practices. [Go to training»](https://carpentries-incubator.github.io/fair-bio-practice/)
 
 
-### How to FAIR
-
-This online web resource is a fantastic option for those involved with data management across any discipline, it is also a great starting point for novices. Within a few hours, those taking the course will learn the FAIR principles, how to work in line with them and how to improve research data management. It is possible to do this learning in sections, it is not required to complete all the stages together making it even easier for those who need to slot it into busy lives.
-
-[Go to training»](https://howtofair.dk/)
+- **How to FAIR**
+This online web resource is a fantastic option for those involved with data management across any discipline, it is also a great starting point for novices. Within a few hours, those taking the course will learn the FAIR principles, how to work in line with them and how to improve research data management. It is possible to do this learning in sections, it is not required to complete all the stages together making it even easier for those who need to slot it into busy lives. [Go to training»](https://howtofair.dk/)
 
 
-### RDMkit
-Recommended in the Horizon Europe Program Guide as the “resource for Data Management guidelines and good practices for the Life Sciences”, RDMkit is an open community project that has become the go-to for resources based on best practice and guidelines of FAIR data management in the life sciences.
+### Additional web resources
+Explore other online resources relevant to RDM and FAIR data for further exploration and reference.
 
-[Go to resource»](https://rdmkit.elixir-europe.org/)
+- **RDMkit**
+Recommended in the Horizon Europe Program Guide as the “resource for Data Management guidelines and good practices for the Life Sciences”, RDMkit is an open community project that has become the go-to for resources based on best practice and guidelines of FAIR data management in the life sciences. [Go to resource»](https://rdmkit.elixir-europe.org/)
 
-### FAIR Cookbook
+- **FAIR Cookbook**
 Recommended in the IMI/IHI Project Guidelines and the Horizon Europe Work Programme for Health as the resource for FAIR Data Management guidelines and good practices for the Life Sciences, FAIR Cookbook contains great guidance as well as fantastic examples of data management across all disciplines.
-This resource is recommended for any researchers who need to consider data management, as well as data stewards.
+This resource is recommended for any researchers who need to consider data management, as well as data stewards. [Go to resource»](https://faircookbook.elixir-europe.org/content/home.html)
 
-[Go to resource»](https://faircookbook.elixir-europe.org/content/home.html)
-
-### GoFAIR – FAIR Principles
+- **GoFAIR – FAIR Principles**
 For those wanting to learn about FAIR principles with real data examples, the GoFAIR content is a great starting point. This content takes each letter of FAIR and breaks down those into their individual principles (for example, F has four sub-categories) with explanations of what they mean, why they are important and then real life examples to help connect that learning to actual data work.
-This is a fantastic resource for anyone working in the life sciences, especially those who wish to link their learning with examples.
+This is a fantastic resource for anyone working in the life sciences, especially those who wish to link their learning with examples. [Go to resource»](https://www.go-fair.org/fair-principles/)
 
-[Go to resource»](https://www.go-fair.org/fair-principles/)
-
-
-### FAIRsharing Educational
-This collection of infographics and factsheets provides high-level information on a variety of topics relevant to FAIRsharing content across a spectrum of users and in all disciplines. This is an excellent resource with content written by the FAIRsharing team and community champions in the field of FAIR research data management.
-
-[Go to resource»](https://fairsharing.org/educational)
+- **FAIRsharing Educational**
+This collection of infographics and factsheets provides high-level information on a variety of topics relevant to FAIRsharing content across a spectrum of users and in all disciplines. This is an excellent resource with content written by the FAIRsharing team and community champions in the field of FAIR research data management. [Go to resource»](https://fairsharing.org/educational)
 
 
 ## Contributors

--- a/_sass/0-settings/_variables.scss
+++ b/_sass/0-settings/_variables.scss
@@ -34,4 +34,5 @@ $font-size-h5: 18px;
 $font-size-h6: 16px;
 
 $heading-line-height: 1.3;
+$heading-small-line-height: 1;
 $heading-letter-spacing: normal;

--- a/_sass/0-settings/_variables.scss
+++ b/_sass/0-settings/_variables.scss
@@ -27,7 +27,7 @@ $heading-font-weight: 700;
 $heading-font-family: 'Lato', 'Arial', sans-serif;
 
 $font-size-h1: 36px;
-$font-size-h2: 28px;
+$font-size-h2: 32px;
 $font-size-h3: 24px;
 $font-size-h4: 20px;
 $font-size-h5: 18px;

--- a/_sass/0-settings/_variables.scss
+++ b/_sass/0-settings/_variables.scss
@@ -27,7 +27,7 @@ $heading-font-weight: 700;
 $heading-font-family: 'Lato', 'Arial', sans-serif;
 
 $font-size-h1: 36px;
-$font-size-h2: 32px;
+$font-size-h2: 42px;
 $font-size-h3: 24px;
 $font-size-h4: 20px;
 $font-size-h5: 18px;

--- a/_sass/1-tools/_shared.scss
+++ b/_sass/1-tools/_shared.scss
@@ -2,9 +2,17 @@
  * Shared declarations for certain elements.
  */
 
-h1, h2, h3, h4, h5, h6,
+h3, h4, h5, h6,
 ul, ol, dl,
-blockquote, p, address,
+blockquote, address,
+hr,
+table,
+fieldset, figure,
+pre {
+  margin-top: 32px;
+}
+
+h1, h2, address,
 hr,
 table,
 fieldset, figure,
@@ -12,6 +20,9 @@ pre {
   margin-bottom: 32px;
 }
 
+p {
+  margin-bottom: 15px;
+}
 
 /**
  * Consistent indentation for lists.

--- a/_sass/1-tools/_shared.scss
+++ b/_sass/1-tools/_shared.scss
@@ -10,9 +10,10 @@ table,
 fieldset, figure,
 pre {
   margin-top: 32px;
+  margin-bottom: 5px;
 }
 
-h1, h2, address,
+h1, address,
 hr,
 table,
 fieldset, figure,
@@ -20,6 +21,7 @@ pre {
   margin-bottom: 32px;
 }
 
+h2,
 p {
   margin-bottom: 15px;
 }

--- a/_sass/2-base/_base.scss
+++ b/_sass/2-base/_base.scss
@@ -36,14 +36,22 @@ body {
 }
 
 h1,
-h2,
+h2
+ {
+  font-family: $heading-font-family;
+  font-weight: $heading-font-weight;
+  line-height: $heading-line-height;
+  letter-spacing: $heading-letter-spacing;
+  color: var(--heading-font-color);
+}
+
 h3,
 h4,
 h5,
 h6 {
   font-family: $heading-font-family;
   font-weight: $heading-font-weight;
-  line-height: $heading-line-height;
+  line-height: $heading-small-line-height;
   letter-spacing: $heading-letter-spacing;
   color: var(--heading-font-color);
 }


### PR DESCRIPTION
This includes updating the recommended resources page to include our courses and materials at the top and indicate that the resources below are other materials for longer pieces of training but not related to our work in the Fellowship. 

The update also includes updates to the scss of headings for margins and sizes as it was not correctly separating sections 