### PR TITLE
changing link_tag to consistent "course" format

### DIFF
--- a/_posts/2023-03-01-carpentries-course-FAIR-agricultural-experiments.md
+++ b/_posts/2023-03-01-carpentries-course-FAIR-agricultural-experiments.md
@@ -8,7 +8,7 @@ image: /images/carpentries.jpg
 tag: [Courses, Plant data]
 featured: true
 go_to: https://carpentries-incubator.github.io/fair-data-management-agriculture/
-link_tag: Carpentries course
+link_tag: course
 ---
 
 ### Who is this lesson for?

--- a/_posts/2023-05-24-carpentries-course-fair-pointers.md
+++ b/_posts/2023-05-24-carpentries-course-fair-pointers.md
@@ -8,7 +8,7 @@ image: /images/carpentries.jpg
 tag: [Courses, FAIR data]
 featured: true
 go_to: https://elixir-uk.github.io/FAIR-Pointers 
-link_tag: Carpentries course
+link_tag: course
 ---
 
 ## Audience and content

--- a/_posts/2023-06-30-carpentries-course-agricultural-data-long-term.md
+++ b/_posts/2023-06-30-carpentries-course-agricultural-data-long-term.md
@@ -8,7 +8,7 @@ image: /images/carpentries.jpg
 tag: [Courses, Plant data, Agricultural data]
 featured: true
 go_to: https://carpentries-incubator.github.io/fair-data-management-agriculture/
-link_tag: Carpentries course
+link_tag: course
 ---
 
 This lesson is aimed at long-term agricultural experiment (LTE) managers, and researchers interested in using long-term agricultural experiment data, who want to apply FAIR principles and good research data management practices to their LTE data. While the target audience for this lesson is therefore LTE managers and researchers, the lesson covers many data management and FAIR data topics relevant to a broader audience working on agricultural field trials.

--- a/_posts/2023-07-23-gtn-tutorial-fair-in-a-nutshell.md
+++ b/_posts/2023-07-23-gtn-tutorial-fair-in-a-nutshell.md
@@ -8,7 +8,7 @@ image:  '/images/gtn-tutorial.jpg'
 tags:   [Courses, FAIR data]
 featured: true
 go_to: https://gxy.io/GTN:T00351
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 

--- a/_posts/2023-07-24-gtn-tutorial-FAIR-data-management-solutions.md
+++ b/_posts/2023-07-24-gtn-tutorial-FAIR-data-management-solutions.md
@@ -8,7 +8,7 @@ image:  '/images/gtn-tutorial.jpg'
 tags:   [Courses, FAIR data]
 featured: false
 go_to: https://gxy.io/GTN:T00349
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 The FAIR (Findable, Accessible, Interoperable, Reusable) data stewardship created the foundation for sharing and publishing digital assets, especially data. This apply to machine accessibility and emphasize that all digital assets should share data in a way that will enable maximum use and reuse.

--- a/_posts/2023-07-25-gtn-tutorial-fair-galaxy-training.md
+++ b/_posts/2023-07-25-gtn-tutorial-fair-galaxy-training.md
@@ -8,7 +8,7 @@ image: /images/gtn-tutorial.jpg
 tag: [Courses, FAIR data]
 featured: true
 go_to: https://gxy.io/GTN:T00350
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 

--- a/_posts/2023-09-05-carpentries-course-rna-seq-ml.md
+++ b/_posts/2023-09-05-carpentries-course-rna-seq-ml.md
@@ -8,7 +8,7 @@ image: /images/carpentries.jpg
 tag: [Courses, Sequencing data, Machine learning]
 featured: true
 go_to: https://carpentries-incubator.github.io/rna-seq-data-for-ml
-link_tag: Carpentries course
+link_tag: course
 ---
 
 This lesson provides a practical guide to sourcing and pre-processing a bulk RNA-Seq dataset for use in a machine learning classification task. The lessons explains the characteristics of a dataset required for this type of analysis, how to search for and download a dataset from each of the main public functional genomics repositories, and then provides guidelines on how to pre-process a dataset to make it machine learning ready, with detailed examples. The lesson finally explains some of the additional data filtering and transformation steps that will improve the performance of machine learning algorithms using RNA-Seq count data.

--- a/_posts/2023-09-11-gtn-tutorial-bioimage-metadata-course.md
+++ b/_posts/2023-09-11-gtn-tutorial-bioimage-metadata-course.md
@@ -8,7 +8,7 @@ image: /images/gtn-tutorial.jpg
 tag: [Courses, Bioimage data]
 featured: false
 go_to: https://gxy.io/GTN:T00362
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 In this Galaxy Training Network tutorial you will:

--- a/_posts/2023-09-11-gtn-tutorial-single-cell.md
+++ b/_posts/2023-09-11-gtn-tutorial-single-cell.md
@@ -8,7 +8,7 @@ image: /images/gtn-tutorial.jpg
 tag: [Courses, Sequencing data, Single-cell data]
 featured: true
 go_to: https://gxy.io/GTN:T00247
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 You’ve done all the work to make a single cell matrix, with gene counts and mitochondrial counts and buckets of cell metadata from all your variables of interest. Now it’s time to fully process your data, to remove low quality cells, to reduce the many dimensions of data that make it difficult to work with, and ultimately to try to define clusters and to find biological meaning and insights.

--- a/_posts/2023-09-27-gtn-tutorial-REMBI-metadata.md
+++ b/_posts/2023-09-27-gtn-tutorial-REMBI-metadata.md
@@ -8,7 +8,7 @@ image: /images/gtn-tutorial.jpg
 tag: [Courses, Bioimage data]
 featured: false
 go_to: https://gxy.io/GTN:T00361
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 In this Galaxy Training Network tutorial you will:

--- a/_posts/2023-09-28-contribution-tutorial-canto.md
+++ b/_posts/2023-09-28-contribution-tutorial-canto.md
@@ -8,7 +8,7 @@ image: /images/contribution-canto.jpg
 tag: [Contribution to resources]
 featured: true
 go_to: https://pombase.github.io/canto_tutorial/
-link_tag: tutorial
+link_tag: course
 ---
 
 Canto is PomBase's online community curation tool. It enables researchers to participate directly in curating data from new publications to support the small staff of professional curators. 

--- a/_posts/2023-09-30-gtn-tutorial-ena-sequence-submission.md
+++ b/_posts/2023-09-30-gtn-tutorial-ena-sequence-submission.md
@@ -8,7 +8,7 @@ image: /images/gtn-tutorial.jpg
 tag: [Courses, Sequencing data]
 featured: true
 go_to: https://gxy.io/GTN:T00369
-link_tag: GTN tutorial
+link_tag: course
 ---
 
 In this Galaxy Training Network tutorial you will learn:

--- a/_posts/2023-11-01-gtn-tutorial-fair-clinical-data.md
+++ b/_posts/2023-11-01-gtn-tutorial-fair-clinical-data.md
@@ -7,7 +7,7 @@ author: [s-ng, t-beck, k-kamieniecka]
 image: /images/gtn-tutorial.jpg
 tag: [Courses, FAIR data, Health data]
 go_to: https://gxy.io/GTN:T00368
-link_tag: GTN tutorial
+link_tag: course
 featured: true 
 ---
 


### PR DESCRIPTION
to avoid confusion with Carpentries course, GTN tutorial or tutorial tags this update will re-name all the lessons tags to course name